### PR TITLE
Added support for onTap event listener

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,6 +30,11 @@ class _MyHomePageState extends State<MyHomePage> {
   String countryValue;
   String stateValue;
   String cityValue;
+
+  void displayMsg(msg) {
+    print(msg);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -54,16 +59,19 @@ class _MyHomePageState extends State<MyHomePage> {
                     countryValue = value;
                   });
                 },
+                onCountryTap: () => displayMsg('You\'ve tapped on countries!'),
                 onStateChanged: (value) {
                   setState(() {
                     stateValue = value;
                   });
                 },
+                onStateTap: () => displayMsg('You\'ve tapped on states!'),
                 onCityChanged: (value) {
                   setState(() {
                     cityValue = value;
                   });
                 },
+                onCityTap: () => displayMsg('You\'ve tapped on cities!'),
               ),
               // InkWell(
               //     onTap: () {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,7 +10,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-       debugShowCheckedModeBanner: false,
+      debugShowCheckedModeBanner: false,
       title: 'Country State and City Picker',
       theme: ThemeData(
         primarySwatch: Colors.blue,
@@ -22,58 +22,58 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  
   @override
   _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-
   String countryValue;
   String stateValue;
   String cityValue;
   @override
   Widget build(BuildContext context) {
-    
     return Scaffold(
       appBar: AppBar(
         title: Text('Country State and City Picker'),
       ),
-      body:  Container(
-        padding: EdgeInsets.symmetric(horizontal: 20),
-        height: 600,
-        child: 
-         Column(
-          children: [
-            SelectState(
-              onCountryChanged: (value) {
-              setState(() {
-                countryValue = value;
-              });
-            },
-            onStateChanged:(value) {
-              setState(() {
-                stateValue = value;
-              });
-            },
-             onCityChanged:(value) {
-              setState(() {
-                cityValue = value;
-              });
-            },
-            
-            ),
-            // InkWell(
-            //   onTap:(){
-            //     print('country selected is $countryValue');
-            //     print('country selected is $stateValue');
-            //     print('country selected is $cityValue');
-            //   },
-            //   child: Text(' Check')
-            // )
-          ],
-        )
-      ),
+      body: Container(
+          padding: EdgeInsets.symmetric(horizontal: 20),
+          height: 600,
+          child: Column(
+            children: [
+              SizedBox(height: 30.0),
+              SelectState(
+                decoration: InputDecoration(
+                    border: OutlineInputBorder(
+                        borderRadius:
+                            const BorderRadius.all(Radius.circular(4.0))),
+                    contentPadding: EdgeInsets.all(5.0)),
+                spacing: 25.0,
+                onCountryChanged: (value) {
+                  setState(() {
+                    countryValue = value;
+                  });
+                },
+                onStateChanged: (value) {
+                  setState(() {
+                    stateValue = value;
+                  });
+                },
+                onCityChanged: (value) {
+                  setState(() {
+                    cityValue = value;
+                  });
+                },
+              ),
+              // InkWell(
+              //     onTap: () {
+              //       print('country selected is $countryValue');
+              //       print('country selected is $stateValue');
+              //       print('country selected is $cityValue');
+              //     },
+              //     child: Text(' Check'))
+            ],
+          )),
     );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,14 +80,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/lib/country_state_city_picker.dart
+++ b/lib/country_state_city_picker.dart
@@ -13,12 +13,17 @@ class SelectState extends StatefulWidget {
   final ValueChanged<String> onCityChanged;
   final TextStyle? style;
   final Color? dropdownColor;
+  final InputDecoration decoration;
+  final double spacing;
 
   const SelectState(
       {Key? key,
       required this.onCountryChanged,
       required this.onStateChanged,
       required this.onCityChanged,
+      this.decoration =
+          const InputDecoration(contentPadding: EdgeInsets.all(0.0)),
+      this.spacing = 0.0,
       this.style,
       this.dropdownColor})
       : super(key: key);
@@ -147,51 +152,80 @@ class _SelectStateState extends State<SelectState> {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
-        DropdownButton<String>(
-          dropdownColor: widget.dropdownColor,
-          isExpanded: true,
-          items: _country.map((String dropDownStringItem) {
-            return DropdownMenuItem<String>(
-              value: dropDownStringItem,
-              child: Row(
-                children: [
-                  Text(
-                    dropDownStringItem,
-                    style: widget.style,
-                  )
-                ],
-              ),
-            );
-          }).toList(),
-          onChanged: (value) => _onSelectedCountry(value!),
-          value: _selectedCountry,
-        ),
-        DropdownButton<String>(
-          dropdownColor: widget.dropdownColor,
-          isExpanded: true,
-          items: _states.map((String dropDownStringItem) {
-            return DropdownMenuItem<String>(
-              value: dropDownStringItem,
-              child: Text(dropDownStringItem, style: widget.style),
-            );
-          }).toList(),
-          onChanged: (value) => _onSelectedState(value!),
-          value: _selectedState,
-        ),
-        DropdownButton<String>(
-          dropdownColor: widget.dropdownColor,
-          isExpanded: true,
-          items: _cities.map((String dropDownStringItem) {
-            return DropdownMenuItem<String>(
-              value: dropDownStringItem,
-              child: Text(dropDownStringItem, style: widget.style),
-            );
-          }).toList(),
-          onChanged: (value) => _onSelectedCity(value!),
-          value: _selectedCity,
+        InputDecorator(
+          decoration: widget.decoration,
+          child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+            dropdownColor: widget.dropdownColor,
+            isExpanded: true,
+            items: _country.map((String dropDownStringItem) {
+              return DropdownMenuItem<String>(
+                value: dropDownStringItem,
+                child: Row(
+                  children: [
+                    Text(
+                      dropDownStringItem,
+                      style: widget.style,
+                    )
+                  ],
+                ),
+              );
+            }).toList(),
+            onChanged: (value) => _onSelectedCountry(value!),
+            value: _selectedCountry,
+          )),
         ),
         SizedBox(
-          height: 10.0,
+          height: widget.spacing,
+        ),
+        InputDecorator(
+          decoration: widget.decoration,
+          child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+            dropdownColor: widget.dropdownColor,
+            isExpanded: true,
+            items: _states.map((String dropDownStringItem) {
+              return DropdownMenuItem<String>(
+                value: dropDownStringItem,
+                child: Row(
+                  children: [
+                    Text(
+                      dropDownStringItem,
+                      style: widget.style,
+                    )
+                  ],
+                ),
+              );
+            }).toList(),
+            onChanged: (value) => _onSelectedState(value!),
+            value: _selectedState,
+          )),
+        ),
+        SizedBox(
+          height: widget.spacing,
+        ),
+        InputDecorator(
+          decoration: widget.decoration,
+          child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+            dropdownColor: widget.dropdownColor,
+            isExpanded: true,
+            items: _cities.map((String dropDownStringItem) {
+              return DropdownMenuItem<String>(
+                value: dropDownStringItem,
+                child: Row(
+                  children: [
+                    Text(
+                      dropDownStringItem,
+                      style: widget.style,
+                    )
+                  ],
+                ),
+              );
+            }).toList(),
+            onChanged: (value) => _onSelectedCity(value!),
+            value: _selectedCity,
+          )),
         ),
       ],
     );

--- a/lib/country_state_city_picker.dart
+++ b/lib/country_state_city_picker.dart
@@ -11,6 +11,9 @@ class SelectState extends StatefulWidget {
   final ValueChanged<String> onCountryChanged;
   final ValueChanged<String> onStateChanged;
   final ValueChanged<String> onCityChanged;
+  final VoidCallback? onCountryTap;
+  final VoidCallback? onStateTap;
+  final VoidCallback? onCityTap;
   final TextStyle? style;
   final Color? dropdownColor;
   final InputDecoration decoration;
@@ -25,7 +28,10 @@ class SelectState extends StatefulWidget {
           const InputDecoration(contentPadding: EdgeInsets.all(0.0)),
       this.spacing = 0.0,
       this.style,
-      this.dropdownColor})
+      this.dropdownColor,
+      this.onCountryTap,
+      this.onStateTap,
+      this.onCityTap})
       : super(key: key);
 
   @override
@@ -171,7 +177,9 @@ class _SelectStateState extends State<SelectState> {
                 ),
               );
             }).toList(),
+            // onTap: ,
             onChanged: (value) => _onSelectedCountry(value!),
+            onTap: widget.onCountryTap,
             value: _selectedCountry,
           )),
         ),
@@ -198,6 +206,7 @@ class _SelectStateState extends State<SelectState> {
               );
             }).toList(),
             onChanged: (value) => _onSelectedState(value!),
+            onTap: widget.onStateTap,
             value: _selectedState,
           )),
         ),
@@ -224,6 +233,7 @@ class _SelectStateState extends State<SelectState> {
               );
             }).toList(),
             onChanged: (value) => _onSelectedCity(value!),
+            onTap: widget.onCityTap,
             value: _selectedCity,
           )),
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -66,14 +66,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
Allows devs to pass a callback function to the widget via an onTap event listener. An example of how this can be useful is in a scenario where a dev wants to lose focus on a text field when the dropdown button is tapped.